### PR TITLE
Refactor HSTX audio processing and improve game settings visibility

### DIFF
--- a/.github/workflows/buildandrelease.yml
+++ b/.github/workflows/buildandrelease.yml
@@ -27,7 +27,7 @@ jobs:
         steps:
                  
           - name: Check out this repository with submodules
-            uses: actions/checkout@v4
+            uses: actions/checkout@v6
             with:
                 submodules: recursive
           
@@ -62,7 +62,7 @@ jobs:
               cp /datalocal/upload/pico-infonesPlus/GBMetadata.zip releases/GBMetadata.zip
 
           - name: Create release
-            uses: softprops/action-gh-release@v2
+            uses: softprops/action-gh-release@v3
             if: startsWith(github.ref, 'refs/tags/')  && github.event_name == 'push'
             with:
                 files: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@
 
 [See setup section in in Pico-infoNesPlus readme how to install and wire up](https://github.com/fhoedemakers/pico-infonesPlus#pico-setup)
 
+# v0.10 Release notes
+
+For the boards that use HSTX in stead of PicoDVI: HDMI audio is now supported via the new HSTX video driver. Huge thanks to [@fliperama86](https://github.com/fliperama86) for the awesome [pico_hdmi](https://github.com/fliperama86/pico_hdmi) driver that made this possible and for helping out.
+
+- Adafruit Fruit Jam.
+- Murmulator M2. 
+
+Other RP2350 configurations that now use HSTX (GPIO 12 - 19) in stead of PicoDVI:
+
+- [Breadboard](https://github.com/fhoedemakers/pico-infonesPlus?tab=readme-ov-file#raspberry-pi-pico-or-pico-2-setup-with-adafruit-hardware-and-breadboard)
+- [PCB](https://github.com/fhoedemakers/pico-infonesPlus?tab=readme-ov-file#pcb-with-raspberry-pi-pico-or-pico-2)
+- [Adafruit Metro RP2350](https://github.com/fhoedemakers/pico-infonesPlus?tab=readme-ov-file#adafruit-metro-rp2350)
+  
+All the other boards still use PicoDVI.
+
+To enable audio over hdmi, make sure external audio is disabled in the settings menu.
+
+- Added option in settings menu to enter bootsel mode for flashing firmware. 
+
 # v0.9 Release Notes
 - Added support for [Murmulator M1 and M2 boards](https://murmulator.ru). [@javavi](https://github.com/javavi)  [#150](https://github.com/fhoedemakers/pico-infonesPlus/issues/150)
   - M1: RP2040/RP2350

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ made the new HDMI output possible, and for all the help along the way.
 
 ## What's new
 
-### Video and sound over a single HDMI cable
+### HSTX Video and sound over HDMI
 
 On the technical side, several RP2350 board configurations have switched
 from the **PicoDVI** software-driven video output to **HSTX**, the
@@ -40,9 +40,7 @@ settings menu. If you'd rather keep using a separate audio output, you
 can switch the HSTX boards to **DVI mode** (video only, no embedded
 sound) from the settings menu. This setting automatically enables external audio in those configurations that support a DAC.
 
-These RP2350 boards have also been switched from PicoDVI to HSTX. They
-keep using a separate audio output for now, but picture quality should
-look the same and the change frees up CPU cycles for future improvements:
+These RP2350 boards have also been switched from PicoDVI to HSTX. (audio and Video):
 
 - [Breadboard build](https://github.com/fhoedemakers/pico-infonesPlus?tab=readme-ov-file#raspberry-pi-pico-or-pico-2-setup-with-adafruit-hardware-and-breadboard)
 - [PCB build](https://github.com/fhoedemakers/pico-infonesPlus?tab=readme-ov-file#pcb-with-raspberry-pi-pico-or-pico-2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # CHANGELOG
 
+> **HSTX replaces PicoDVI** on more boards, **HSTX now has picture and sound over HDMI**, and you can enter flashing mode from the settings menu.
+
 # General Info
 
 [Binaries for each configuration and PCB design are at the end of this page](#downloads___).
@@ -8,41 +10,61 @@
 
 # v0.10 Release notes
 
-For the boards that use HSTX in stead of PicoDVI: HDMI audio is now supported via the new HSTX video driver. Huge thanks to [@fliperama86](https://github.com/fliperama86) for the awesome [pico_hdmi](https://github.com/fliperama86/pico_hdmi) driver that made this possible and for helping out.
+This release brings picture and sound together over a single HDMI cable on
+more boards, switches additional RP2350 configurations from PicoDVI to
+HSTX, and adds a small convenience for flashing new firmware.
 
-- Adafruit Fruit Jam.
-- Murmulator M2. 
+A huge thank you to [@fliperama86](https://github.com/fliperama86) for the
+excellent [pico_hdmi](https://github.com/fliperama86/pico_hdmi) driver that
+made the new HDMI output possible, and for all the help along the way.
 
-Other RP2350 configurations that now use HSTX (GPIO 12 - 19) in stead of PicoDVI:
+## What's new
 
-- [Breadboard](https://github.com/fhoedemakers/pico-infonesPlus?tab=readme-ov-file#raspberry-pi-pico-or-pico-2-setup-with-adafruit-hardware-and-breadboard)
-- [PCB](https://github.com/fhoedemakers/pico-infonesPlus?tab=readme-ov-file#pcb-with-raspberry-pi-pico-or-pico-2)
+### Video and sound over a single HDMI cable
+
+On the technical side, several RP2350 board configurations have switched
+from the **PicoDVI** software-driven video output to **HSTX**, the
+RP2350's dedicated High-Speed Serial Transmit hardware (GPIO 12 – 19).
+HSTX has been used for video on some boards before, but in this release
+it also carries **audio embedded in the HDMI stream** for the first
+time — that's the new capability HSTX gains here. (PicoDVI has always
+been able to embed audio; HSTX is just catching up on that front while
+offloading the work from the CPU to dedicated hardware.)
+
+In practice, on these boards picture and sound now travel together over a
+single HDMI cable — no separate audio jack needed:
+
+- Adafruit Fruit Jam
+- Murmulator M2
+
+To enable audio over HDMI, make sure external audio is disabled in the
+settings menu. If you'd rather keep using a separate audio output, you
+can switch the HSTX boards to **DVI mode** (video only, no embedded
+sound) from the settings menu.
+
+These RP2350 boards have also been switched from PicoDVI to HSTX. They
+keep using a separate audio output for now, but picture quality should
+look the same and the change frees up CPU cycles for future improvements:
+
+- [Breadboard build](https://github.com/fhoedemakers/pico-infonesPlus?tab=readme-ov-file#raspberry-pi-pico-or-pico-2-setup-with-adafruit-hardware-and-breadboard)
+- [PCB build](https://github.com/fhoedemakers/pico-infonesPlus?tab=readme-ov-file#pcb-with-raspberry-pi-pico-or-pico-2)
 - [Adafruit Metro RP2350](https://github.com/fhoedemakers/pico-infonesPlus?tab=readme-ov-file#adafruit-metro-rp2350)
-  
-All the other boards still use PicoDVI.
 
-To enable audio over hdmi, make sure external audio is disabled in the settings menu.
+All other boards continue to use PicoDVI and work as before.
 
-- Added option in settings menu to enter bootsel mode for flashing firmware. 
+### New options and conveniences
 
-# v0.9 Release Notes
-- Added support for [Murmulator M1 and M2 boards](https://murmulator.ru). [@javavi](https://github.com/javavi)  [#150](https://github.com/fhoedemakers/pico-infonesPlus/issues/150)
-  - M1: RP2040/RP2350
-  - M2: RP2350 only
-  **Note**: These Murmulator M1 and M2 builds are untested. Please report any issues.
-- **Fruit Jam only**: Add volume controls to settings menu. Can also be changed in-game via (START + LEFT/RIGHT). Note that too high volume levels may cause distortion. (Ext speaker, advised 16 db max, internal advised 18 dB max). Latest metadata package includes a sample.wav file to test the volume level.
-- Updated GBMetaData.zip: Added **sample.wav**. This sample will be played when using the Fruit Jam volume control in the settings menu. Note when **/soundrecorder.wav** is found, this file will be played in stead.
-- Updated the menu to also list .wav audio files.
-- Added basic wav audio playback from within the menu. Press BUTTON2 or START to play the wav file. Tested with https://lonepeakmusic.itch.io/retro-midi-music-pack-1 The wav file must have the following specs:
-  - 16/24 bit PCM wav files only.  (24 bit files are downsampled to 16 bit) 
-  - 2ch stereo only.
-  - Sample rate supported: 44100.
-- **RP2350 with PSRAM only**: Record about 30 seconds of audio by pressing START to pause the game and then START + BUTTON1. Audio is recorded to **/soundrecorder.wav** on the SD-card.
+- **Enter flashing mode from the settings menu**, so you can update the
+  firmware without having to unplug the device and hold the BOOTSEL button.
 
-## Fixes
+### Reliability
 
-- Fruit Jam audio fixes.
-- Settings changed by in-game button combos are saved when exiting to menu.
+- **Resync watchdog for HSTX output.** On the new HSTX output when set
+  to video-only (DVI) mode, the monitor could occasionally lose the
+  picture. The emulator now detects this and automatically restores the
+  signal without needing a restart. (Not observed in full HDMI mode, but
+  the same safety net is enabled there too just in case.)
+
 
 # previous changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,7 @@
 
 # v0.10 Release notes
 
-This release brings picture and sound together over a single HDMI cable on
-more boards, switches additional RP2350 configurations from PicoDVI to
-HSTX, and adds a small convenience for flashing new firmware.
+In this release PicoDVI is replaced with HSTX where possible, implements audio over HDMI using HSTX and adds a small convenience for flashing new firmware.
 
 A huge thank you to [@fliperama86](https://github.com/fliperama86) for the
 excellent [pico_hdmi](https://github.com/fliperama86/pico_hdmi) driver that
@@ -40,7 +38,7 @@ single HDMI cable — no separate audio jack needed:
 To enable audio over HDMI, make sure external audio is disabled in the
 settings menu. If you'd rather keep using a separate audio output, you
 can switch the HSTX boards to **DVI mode** (video only, no embedded
-sound) from the settings menu.
+sound) from the settings menu. This setting automatically enables external audio in those configurations that support a DAC.
 
 These RP2350 boards have also been switched from PicoDVI to HSTX. They
 keep using a separate audio output for now, but picture quality should

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,7 @@ target_compile_definitions(${projectname} PUBLIC
     ENABLE_SOUND=1
     PEANUT_FULL_GBC_SUPPORT=1
     WIIPAD_DELAYED_START=${WIIPAD_DELAYED_START} # Delay Wii Pad initialization to avoid I2C errors
+    #ENABLEDVI=1
     )
 if(NOT PICO_PLATFORM STREQUAL "rp2040")
     message(STATUS "Using PICO_PIO_USE_GPIO_BASE=1 for non-rp2040 platforms.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,7 @@ target_compile_definitions(${projectname} PUBLIC
     ENABLE_SOUND=1
     PEANUT_FULL_GBC_SUPPORT=1
     WIIPAD_DELAYED_START=${WIIPAD_DELAYED_START} # Delay Wii Pad initialization to avoid I2C errors
-    #ENABLEDVI=1
+    ENABLEDVI=1
     )
 if(NOT PICO_PLATFORM STREQUAL "rp2040")
     message(STATUS "Using PICO_PIO_USE_GPIO_BASE=1 for non-rp2040 platforms.")

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,23 @@
 # History of changes
 
+# v0.9 Release Notes
+- Added support for [Murmulator M1 and M2 boards](https://murmulator.ru). [@javavi](https://github.com/javavi)  [#150](https://github.com/fhoedemakers/pico-infonesPlus/issues/150)
+  - M1: RP2040/RP2350
+  - M2: RP2350 only
+  **Note**: These Murmulator M1 and M2 builds are untested. Please report any issues.
+- **Fruit Jam only**: Add volume controls to settings menu. Can also be changed in-game via (START + LEFT/RIGHT). Note that too high volume levels may cause distortion. (Ext speaker, advised 16 db max, internal advised 18 dB max). Latest metadata package includes a sample.wav file to test the volume level.
+- Updated GBMetaData.zip: Added **sample.wav**. This sample will be played when using the Fruit Jam volume control in the settings menu. Note when **/soundrecorder.wav** is found, this file will be played in stead.
+- Updated the menu to also list .wav audio files.
+- Added basic wav audio playback from within the menu. Press BUTTON2 or START to play the wav file. Tested with https://lonepeakmusic.itch.io/retro-midi-music-pack-1 The wav file must have the following specs:
+  - 16/24 bit PCM wav files only.  (24 bit files are downsampled to 16 bit) 
+  - 2ch stereo only.
+  - Sample rate supported: 44100.
+- **RP2350 with PSRAM only**: Record about 30 seconds of audio by pressing START to pause the game and then START + BUTTON1. Audio is recorded to **/soundrecorder.wav** on the SD-card.
+
+## Fixes
+
+- Fruit Jam audio fixes.
+- Settings changed by in-game button combos are saved when exiting to menu.
 # v0.8 Release Notes
 
 - Settings are saved to /settings_gb.dat instead of /settings.dat. This allows to have separate settings files for different emulators (e.g. pico-infonesPlus and pico-peanutGB etc.).

--- a/main.cpp
+++ b/main.cpp
@@ -39,7 +39,7 @@ const int8_t g_settings_visibility_gb[MOPT_COUNT] = {
     1,                               // FPS Overlay
     0,                               // Audio Enable
     0,                               // Frame Skip
-    (EXT_AUDIO_IS_ENABLED && !HSTX), // External Audio
+    (EXT_AUDIO_IS_ENABLED), // External Audio
     1,                               // Font Color
     1,                               // Font Back Color
     ENABLE_VU_METER,                 // VU Meter
@@ -230,6 +230,8 @@ static void inline processaudioPerFrameHSTX() {
             addSampleToVUMeter(l);
         } 
 #endif
+       l = l >> 2;
+         r = r >> 2;
        hstx_push_audio_sample(l, r);
        i++;
     }
@@ -405,7 +407,14 @@ void inline output_audio_per_frame()
 #endif
 #else
     // processaudioPerFrameI2S();
-    processaudioPerFrameHSTX();
+    if (settings.flags.useExtAudio == 1)
+    {
+        processaudioPerFrameI2S();
+    }
+    else
+    {
+        processaudioPerFrameHSTX();
+    }
 #endif
 }
 static DWORD prevButtons[2]{};

--- a/main.cpp
+++ b/main.cpp
@@ -831,6 +831,7 @@ int main()
         uint8_t *rom = reinterpret_cast<unsigned char *>(ROM_FILE_ADDR);
         if (startemulation(rom, romName, GAMESAVEDIR, ErrorMessage, HSTX))
         {
+            Frens::PaceFrames60fps(true); 
             process();
             stopemulation(romName, GAMESAVEDIR);
         }

--- a/main.cpp
+++ b/main.cpp
@@ -238,6 +238,7 @@ static void inline processaudioPerFrameHSTX() {
         {
             if (hstx_di_queue_get_level() >= HSTX_AUDIO_DI_HIGH_WATERMARK)
             {
+                //printf("HSTX audio queue full, dropping audio frame\n");
                 acc_count = 0;
                 return;
             }

--- a/main.cpp
+++ b/main.cpp
@@ -49,7 +49,7 @@ const int8_t g_settings_visibility_gb[MOPT_COUNT] = {
     1,                               // Border Mode (Super Gameboy style borders not applicable for NES)
     0,                               // Rapid Fire on A
     0,                                // Rapid Fire on B
-     1                                // Enter bootsel mode (moved from button combo to settings menu, but keep option visible for NES)
+    1                                // Enter bootsel mode
 
 };
 const uint8_t g_available_screen_modes_gb[] = {

--- a/main.cpp
+++ b/main.cpp
@@ -757,8 +757,8 @@ void __not_in_flash_func(process)()
     int frametime = 0;
     while (reset == false)
     {
-        //Frens::PaceFrames60fps(false);
-        Frens::waitForVSync();
+        Frens::PaceFrames60fps(false);
+        //Frens::waitForVSync();
         processinput(false, &pdwPad1, &pdwPad2, &pdwSystem, false, nullptr);
         ti1 = Frens::time_us();
         emu_run_frame();
@@ -808,6 +808,8 @@ int main()
         FrensSettings::savesettings();
     }
     scaleMode8_7_ = Frens::applyScreenMode(settings.screenMode);
+#else
+    hstx_setScanLines(settings.flags.scanlineOn);
 #endif
 
     bool showSplash = true;

--- a/main.cpp
+++ b/main.cpp
@@ -757,7 +757,8 @@ void __not_in_flash_func(process)()
     int frametime = 0;
     while (reset == false)
     {
-        Frens::PaceFrames60fps(false);
+        //Frens::PaceFrames60fps(false);
+        Frens::waitForVSync();
         processinput(false, &pdwPad1, &pdwPad2, &pdwSystem, false, nullptr);
         ti1 = Frens::time_us();
         emu_run_frame();

--- a/main.cpp
+++ b/main.cpp
@@ -207,11 +207,10 @@ static void inline processaudioPerFrameDVI()
         i += n;
     }
 }
-#endif
+#else
 // Global HDMI audio frame counter shared across HSTX audio paths
 static int g_hdmi_audio_frame_counter = 0;
 static void inline processaudioPerFrameHSTX() {
-#if HSTX 
     static audio_sample_t acc_buf[4];
     static int acc_count = 0;
     // For HSTX with PicoHDMI, we can use the same improved I2S path as non-HSTX, since PicoHDMI also uses I2S for audio output.
@@ -234,9 +233,9 @@ static void inline processaudioPerFrameHSTX() {
          r = r >> 2;
        hstx_push_audio_sample(l, r);
        i++;
-    }
-#endif    
+    } 
 }
+#endif
 
 // #define IMPROVED_I2S_DISABLE 0 // set to 1 to disable improved I2S path and use legacy simple path
 static void inline processaudioPerFrameI2S()

--- a/main.cpp
+++ b/main.cpp
@@ -48,7 +48,8 @@ const int8_t g_settings_visibility_gb[MOPT_COUNT] = {
     1,                               // DMG Palette (NES emulator does not use GameBoy palettes)
     1,                               // Border Mode (Super Gameboy style borders not applicable for NES)
     0,                               // Rapid Fire on A
-    0                                // Rapid Fire on B
+    0,                                // Rapid Fire on B
+     1                                // Enter bootsel mode (moved from button combo to settings menu, but keep option visible for NES)
 
 };
 const uint8_t g_available_screen_modes_gb[] = {
@@ -390,30 +391,17 @@ static void inline processaudioPerFrameI2S()
 }
 void inline output_audio_per_frame()
 {
-
-#if !HSTX
 #if EXT_AUDIO_IS_ENABLED
     if (settings.flags.useExtAudio == 1)
     {
         processaudioPerFrameI2S();
+        return;
     }
-    else
-    {
-        processaudioPerFrameDVI();
-    }
-#else
-    processaudioPerFrameDVI();
 #endif
+#if !HSTX
+    processaudioPerFrameDVI();
 #else
-    // processaudioPerFrameI2S();
-    if (settings.flags.useExtAudio == 1)
-    {
-        processaudioPerFrameI2S();
-    }
-    else
-    {
-        processaudioPerFrameHSTX();
-    }
+    processaudioPerFrameHSTX();
 #endif
 }
 static DWORD prevButtons[2]{};

--- a/main.cpp
+++ b/main.cpp
@@ -33,17 +33,19 @@
 // Order must match enum in menu_options.h
 const int8_t g_settings_visibility_gb[MOPT_COUNT] = {
     0,                               // Exit Game, or back to menu. Always visible when in-game.
+    0,                               // Reset Game. Always visible when in-game.
     -1,                              // No save state support
     !HSTX,                           // Screen Mode (only when not HSTX)
     HSTX,                            // Scanlines toggle (only when HSTX)
     1,                               // FPS Overlay
     0,                               // Audio Enable
     0,                               // Frame Skip
+    (HSTX && ENABLEDVI),                     // Display Mode (only when DVI is enabled)
     (EXT_AUDIO_IS_ENABLED), // External Audio
     1,                               // Font Color
     1,                               // Font Back Color
     ENABLE_VU_METER,                 // VU Meter
-    (HW_CONFIG == 8),                // Fruit Jam Internal Speaker
+    //(HW_CONFIG == 8),                // Fruit Jam Internal Speaker
     (HW_CONFIG == 8),                // Fruit Jam Volume Control
     1,                               // DMG Palette (NES emulator does not use GameBoy palettes)
     1,                               // Border Mode (Super Gameboy style borders not applicable for NES)
@@ -80,8 +82,8 @@ static char fpsString[3] = "00";
 #define FPSSTART (((MARGINTOP + 7) / 8) * 8)
 #define FPSEND ((FPSSTART) + 8)
 
-bool reset = false;
-
+static bool reset = false;
+static bool resetGame = false;
 #ifndef NORENDER
 #define NORENDER 0 // 0 is render frames in emulation loop
 #endif
@@ -392,7 +394,7 @@ static void inline processaudioPerFrameI2S()
 void inline output_audio_per_frame()
 {
 #if EXT_AUDIO_IS_ENABLED
-    if (settings.flags.useExtAudio == 1)
+    if (settings.flags.useExtAudio == 1 || Frens::isHeadPhoneJackConnected())
     {
         processaudioPerFrameI2S();
         return;
@@ -634,6 +636,9 @@ int ProcessAfterFrameIsRendered(bool frommenu)
         {
             reset = true;
         }
+        if (rval == 5) {
+           reset = resetGame = true;
+        }
         loadoverlay(); // reload overlay to show any changes
         emu_set_dmg_palette_type((dmg_palette_type_t)settings.flags.dmgLCDPalette); // in case palette was changed, GameBoy Specific
     }
@@ -759,6 +764,7 @@ void __not_in_flash_func(process)()
     {
         Frens::PaceFrames60fps(false);
         //Frens::waitForVSync();
+        Frens::pollHeadPhoneJack();
         processinput(false, &pdwPad1, &pdwPad2, &pdwSystem, false, nullptr);
         ti1 = Frens::time_us();
         emu_run_frame();
@@ -821,20 +827,24 @@ int main()
         {
             menu("Pico-PeanutGB", ErrorMessage, isFatalError, showSplash, ".gb .gbc", selectedRom); 
         }
-        reset = false;
+      
         printf("Now playing: %s\n", selectedRom);
-
         printf("Initializing Game Boy Emulator\n");
-        EXT_AUDIO_MUTE_INTERNAL_SPEAKER(settings.flags.fruitJamEnableInternalSpeaker == 0);
-        loadoverlay(); // load default overlay
-        emu_set_dmg_palette_type((dmg_palette_type_t)settings.flags.dmgLCDPalette);
-        uint8_t *rom = reinterpret_cast<unsigned char *>(ROM_FILE_ADDR);
-        if (startemulation(rom, romName, GAMESAVEDIR, ErrorMessage, HSTX))
-        {
-            Frens::PaceFrames60fps(true); 
-            process();
-            stopemulation(romName, GAMESAVEDIR);
-        }
+        do {
+            reset = false;
+            resetGame = false;
+            // EXT_AUDIO_MUTE_INTERNAL_SPEAKER(settings.flags.fruitJamEnableInternalSpeaker == 0);
+            EXT_AUDIO_SETVOLUME(settings.fruitjamVolumeLevel);
+            loadoverlay(); // load default overlay
+            emu_set_dmg_palette_type((dmg_palette_type_t)settings.flags.dmgLCDPalette);
+            uint8_t *rom = reinterpret_cast<unsigned char *>(ROM_FILE_ADDR);
+            if (startemulation(rom, romName, GAMESAVEDIR, ErrorMessage, HSTX))
+            {
+                Frens::PaceFrames60fps(true); 
+                process();
+                stopemulation(romName, GAMESAVEDIR);
+            }
+        } while (resetGame);
         selectedRom[0] = 0;
         showSplash = false;
     }

--- a/splash.cpp
+++ b/splash.cpp
@@ -35,9 +35,9 @@ void splash()
     strcpy(s, "@shuichi_takano");
     putText(SCREEN_COLS / 2 - strlen(s) / 2, 15, s, CLIGHTBLUE, bgcolorSplash);
 #else
-    strcpy(s, "HSTX video driver & I2S audio");
+    strcpy(s, "HSTX video driver _ I2S audio___");
     putText(SCREEN_COLS / 2 - strlen(s) / 2, 14, s, fgcolorSplash, bgcolorSplash);
-    strcpy(s, "@frenskefrens");
+    strcpy(s, "__@fliperama86____@frenskefrens__");
     putText(SCREEN_COLS / 2 - strlen(s) / 2, 15, s, CLIGHTBLUE, bgcolorSplash);
 #endif
     strcpy(s, "(S)NES/WII controller support");


### PR DESCRIPTION
This pull request introduces significant updates focused on HDMI output, audio handling, and user convenience features, especially for RP2350-based boards. The main highlight is the migration from PicoDVI to HSTX for video (and now audio) output on supported boards, providing HDMI audio support and improved reliability. The release also adds a new option to enter flashing mode from the settings menu, updates build dependencies, and improves the audio output logic.

**HDMI Output and Audio Improvements:**

* Replaced PicoDVI with HSTX (hardware HDMI) for video output on several RP2350 boards, and enabled audio over HDMI using HSTX. This offloads work from the CPU and allows picture and sound to travel together over a single HDMI cable. A resync watchdog was also added to improve reliability if the monitor loses signal.
* Refactored audio output logic in `main.cpp` to support HSTX audio, including a new `processaudioPerFrameHSTX()` function and updated output selection logic to handle I2S and HDMI paths more robustly. [[1]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbR213-R240) [[2]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbL365-R406)
* Added compile-time flag `ENABLEDVI` to `CMakeLists.txt` to better control DVI/HDMI build options.

**User Experience and Menu Enhancements:**

* Added the ability to enter flashing (BOOTSEL) mode directly from the settings menu, making firmware updates more convenient. Also updated menu visibility logic for new and existing options. [[1]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbR36-R54) [[2]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbR639-R641)
* Improved headphone jack detection and polling to better handle external audio switching.

**General Maintenance and Documentation:**

* Updated release notes in `CHANGELOG.md` to document the new HSTX HDMI audio/video support and other improvements.
* Updated build workflow dependencies to the latest major versions for `actions/checkout` and `softprops/action-gh-release`. [[1]](diffhunk://#diff-59c29f9875425a341116e40441dc56d9ab6f01416817054bfaf1605e05360f33L30-R30) [[2]](diffhunk://#diff-59c29f9875425a341116e40441dc56d9ab6f01416817054bfaf1605e05360f33L65-R65)
* Updated submodule `pico_shared` to the latest commit.
* Minor updates to splash screen credits and legacy documentation. [[1]](diffhunk://#diff-dc2914c998f3bf03a87878e243a368e97c56215d3d5837b871503de7df22b988L38-R40) [[2]](diffhunk://#diff-648afe3d986261d8f2015b2b131b0e4a448d4dc6946cfde1a7a836876cee255eR3-R20)

These changes collectively modernize the HDMI output stack, improve audio handling, and make the firmware easier to update and use.This pull request introduces significant improvements and new features, most notably the addition of HDMI audio support for boards using the HSTX video driver (via the new `pico_hdmi` driver), an option to enter bootsel mode for firmware flashing, and several adjustments to the settings and audio processing logic to accommodate these updates. There are also minor UI and codebase enhancements.

**Major new features and hardware support:**

* Added HDMI audio support for HSTX-based boards using the new `pico_hdmi` driver, with thanks to @fliperama86. This allows audio over HDMI for supported configurations, and updates the documentation accordingly.
* Updated audio processing logic to route audio correctly depending on whether HSTX is enabled, including a new `processaudioPerFrameHSTX()` function for HDMI audio output. [[1]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbR213-R240) [[2]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbL365-R406)
* Boards using HSTX (GPIO 12-19) now include Breadboard, PCB, and Adafruit Metro RP2350 configurations, as described in the updated changelog.

**Settings and menu improvements:**

* Added a new option in the settings menu to enter bootsel mode for firmware flashing, and updated the settings visibility logic to include this and other new/adjusted menu items. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR9-R27) [[2]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbR36-R54)
* Improved handling of game and system reset logic, allowing for both soft and hard resets via the menu. [[1]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbR639-R641) [[2]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbL794-R847)

**Audio and hardware abstraction enhancements:**

* Integrated headphone jack detection and switching between audio outputs, and ensured correct audio initialization for both HSTX and non-HSTX paths. [[1]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbL365-R406) [[2]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbR766-R767) [[3]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbR806-R808) [[4]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbR817-R818)

**UI and codebase updates:**

* Updated splash screen credits to reflect new contributors and hardware support.
* Updated the `pico_shared` submodule to the latest commit.