### PR TITLE
Update pico_shared and revert PCB to version 2.1

### DIFF
--- a/.github/workflows/buildandrelease.yml
+++ b/.github/workflows/buildandrelease.yml
@@ -67,9 +67,9 @@ jobs:
             with:
                 files: |
                        releases/*.uf2
-                       PCB/pico_nesPCB_v2.1.zip  
-                       PCB/Gerber_PicoNES_Mini_PCB_v2.0.zip
-                       PCB/Gerber_PicoNES_Micro_v1.2.zip
+                       pico_shared/PCB/pico_nesPCB_v2.3.zip  
+                       pico_shared/PCB/Gerber_PicoNES_Mini_PCB_v2.0.zip
+                       pico_shared/PCB/Gerber_PicoNES_Micro_v1.2.zip
                        releases/GBMetadata.zip       
                 body_path: CHANGELOG.md
           

--- a/.github/workflows/buildandrelease.yml
+++ b/.github/workflows/buildandrelease.yml
@@ -67,7 +67,7 @@ jobs:
             with:
                 files: |
                        releases/*.uf2
-                       pico_shared/PCB/pico_nesPCB_v2.3.zip  
+                       pico_shared/PCB/pico_nesPCB_v2.1.zip  
                        pico_shared/PCB/Gerber_PicoNES_Mini_PCB_v2.0.zip
                        pico_shared/PCB/Gerber_PicoNES_Micro_v1.2.zip
                        releases/GBMetadata.zip       

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,7 +97,7 @@ For some configurations risc-v binaries are available. It is recommended however
 | Pico 2 | [PicoPeanutGB_AdafruitDVISD_pico2_arm.uf2](https://github.com/fhoedemakers/pico-peanutGB/releases/latest/download/PicoPeanutGB_AdafruitDVISD_pico2_arm.uf2) | [Readme](https://github.com/fhoedemakers/pico-infonesPlus/blob/main/README.md#pcb-with-raspberry-pi-pico-or-pico-2) |
 | Pico 2 W | [PicoPeanutGB_AdafruitDVISD_pico2_w_arm.uf2](https://github.com/fhoedemakers/pico-peanutGB/releases/latest/download/PicoPeanutGB_AdafruitDVISD_pico2_w_arm.uf2) | [Readme](https://github.com/fhoedemakers/pico-infonesPlus/blob/main/README.md#pcb-with-raspberry-pi-pico-or-pico-2) |
 
-PCB [pico_nesPCB_v2.1.zip](https://github.com/fhoedemakers/pico-peanutGB/releases/latest/download/pico_nesPCB_v2.1.zip)
+PCB [pico_nesPCB_v2.3.zip](https://github.com/fhoedemakers/pico-peanutGB/releases/latest/download/pico_nesPCB_v2.3.zip)
 
 3D-printed case designs for PCB:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-> **HSTX replaces PicoDVI** on more boards, **HSTX now has picture and sound over HDMI**, and you can enter flashing mode from the settings menu.
+Adds support for **pico-bootLoader**, which allows several emulators to be installed on a single board and selected at power-on. Also adds a **controller test screen**, an **LCD scanline type**, wider controller support and a number of stability fixes.
 
 # General Info
 
@@ -8,58 +8,126 @@
 
 [See setup section in in Pico-infoNesPlus readme how to install and wire up](https://github.com/fhoedemakers/pico-infonesPlus#pico-setup)
 
-# v0.10 Release notes
+# v0.11 Release notes
 
-In this release PicoDVI is replaced with HSTX where possible, implements audio over HDMI using HSTX and adds a small convenience for flashing new firmware.
+This release adds support for pico-bootLoader, extends controller
+support, introduces a controller test screen and an additional display
+option, and contains a number of stability fixes.
 
-A huge thank you to [@fliperama86](https://github.com/fliperama86) for the
-excellent [pico_hdmi](https://github.com/fliperama86/pico_hdmi) driver that
-made the new HDMI output possible, and for all the help along the way.
+## Support for pico-bootLoader
+
+An RP2350 board normally holds a single program. Running a different
+emulator requires connecting the board to a computer, holding BOOTSEL
+and copying a different `.uf2` file onto it.
+
+[pico-bootLoader](https://github.com/fhoedemakers/pico-bootLoader)
+removes that requirement. The loader is flashed onto the board once, the
+applications are placed on the SD card, and from then on a menu is shown
+at every power-on. The menu is operated with a USB game controller or a
+USB keyboard and can be displayed either with cover artwork per
+application or as plain text. Selecting an entry starts the
+corresponding application; a reset or power cycle returns to the menu.
+
+Besides this Game Boy / Game Boy Color emulator, the loader supports the
+NES, Sega Genesis / Mega Drive, Sega Master System / Game Gear,
+PC Engine and Philips Videopac / Odyssey² emulators, as well as a native
+port of *Doom*.
+
+Please note:
+
+- The binaries listed on this page are the standalone builds and are
+  unchanged. Use one of these to run the Game Boy emulator on its own.
+- The builds intended for the loader are published in the pico-bootLoader
+  repository, not here. See the [pico-bootLoader releases
+  page](https://github.com/fhoedemakers/pico-bootLoader/releases) for
+  those files and for the installation instructions.
+- When the emulator is started from the loader, the settings menu
+  contains an additional entry, **Return to emulator selection**, which
+  returns to the application menu. This entry is not present in
+  standalone builds.
 
 ## What's new
 
-### HSTX Video and sound over HDMI
+### Controller Test screen
 
-On the technical side, several RP2350 board configurations have switched
-from the **PicoDVI** software-driven video output to **HSTX**, the
-RP2350's dedicated High-Speed Serial Transmit hardware (GPIO 12 – 19).
-HSTX has been used for video on some boards before, but in this release
-it also carries **audio embedded in the HDMI stream** for the first
-time — that's the new capability HSTX gains here. (PicoDVI has always
-been able to embed audio; HSTX is just catching up on that front while
-offloading the work from the CPU to dedicated hardware.)
+The settings menu contains a new entry, **Controller Test**. It displays
+a controller layout on screen and highlights each button while it is
+pressed, following the most recently used input source: the controller
+ports on the board, USB controllers 1 and 2, and a Wii Classic
+controller. A list below the layout shows the connection status of each
+source and whether input has been received from it.
 
-In practice, on these boards picture and sound now travel together over a
-single HDMI cable — no separate audio jack needed:
+Hold **SELECT + START** for two seconds to leave the screen.
 
-- Adafruit Fruit Jam
-- Murmulator M2
+### Display options
 
-To enable audio over HDMI, make sure external audio is disabled in the
-settings menu. If you'd rather keep using a separate audio output, you
-can switch the HSTX boards to **DVI mode** (video only, no embedded
-sound) from the settings menu. This setting automatically enables external audio in those configurations that support a DAC.
+- New **Scanline Type** option with the values *Simple* and *LCD*. Simple
+  darkens alternate lines; LCD darkens alternate columns as well,
+  resulting in a grid pattern that resembles an LCD screen.
+- The separate **Scanlines** on/off option has been removed. Scanlines
+  are now selected through the **Screen Mode** option.
 
-These RP2350 boards have also been switched from PicoDVI to HSTX. (audio and Video):
+### Settings menu
 
-- [Breadboard build](https://github.com/fhoedemakers/pico-infonesPlus?tab=readme-ov-file#raspberry-pi-pico-or-pico-2-setup-with-adafruit-hardware-and-breadboard)
-- [PCB build](https://github.com/fhoedemakers/pico-infonesPlus?tab=readme-ov-file#pcb-with-raspberry-pi-pico-or-pico-2)
-- [Adafruit Metro RP2350](https://github.com/fhoedemakers/pico-infonesPlus?tab=readme-ov-file#adafruit-metro-rp2350)
+- The option list is now scrollable, so that all options remain
+  accessible as their number increases. The SAVE, CANCEL and DEFAULT
+  actions are shown at a fixed position.
+- The software version is displayed in the menu.
 
-All other boards continue to use PicoDVI and work as before.
+### Menu and SD card
 
-### New options and conveniences
+- The default directory for roms is now **`/roms/GB`**. Roms may still be
+  placed anywhere on the card and organised in subdirectories.
+- When leaving a subdirectory, the selection returns to the directory
+  that was left instead of the first entry in the list.
+- If the last used directory no longer exists, the menu falls back to the
+  root of the card.
 
-- **Enter flashing mode from the settings menu**, so you can update the
-  firmware without having to unplug the device and hold the BOOTSEL button.
+### Controller support
 
-### Reliability
+- Shoulder buttons are now mapped on the **DualShock 4**, **DualSense**,
+  **Xbox / XInput** controllers, the **MantaPad** and the **Retro-bit
+  Mega Drive Arcade Pad**. The Square button is mapped on the
+  **PlayStation Classic** controller, and L/R and ZL/ZR are mapped on the
+  **Wii Classic Controller**. Additional keys were added to the USB
+  keyboard mapping.
+- On XInput controllers, the left thumbstick also functions as a d-pad.
+- **SNES controllers** connected to the controller port on the board are
+  now fully supported. NES controllers are detected automatically and are
+  unaffected.
 
-- **Resync watchdog for HSTX output.** On the new HSTX output when set
-  to video-only (DVI) mode, the monitor could occasionally lose the
-  picture. The emulator now detects this and automatically restores the
-  signal without needing a restart. (Not observed in full HDMI mode, but
-  the same safety net is enabled there too just in case.)
+## Fixes
+
+### Display
+
+- Corrected the alignment of the frame buffer, which could cause crashes
+  and corrupted scanlines.
+- The HDMI output pins are configured with a higher drive strength and a
+  faster slew rate, which improves signal quality on longer or
+  lower-quality cables.
+
+### Stability
+
+- Fixed a crash when loading larger roms, caused by the rom data
+  overwriting the area of flash memory in which the board parameters are
+  stored.
+- Fixed a possible stack overflow when saving or loading settings, which
+  could cause a crash on boards with limited memory.
+- The SD card driver has been updated with a number of reliability
+  improvements, including card detection after a reset.
+- **Adafruit Fruit Jam and Adafruit Feather RP2350 only:** fixed
+  initialisation of the audio DAC failing when a NES- or
+  SNES-Classic-Mini controller is connected at power-on. These
+  controllers interfere with the I2C bus that is shared with the DAC. A
+  controller connected at power-on is now also usable from the first menu
+  screen.
+
+## Please note
+
+- Settings are reset to their default values the first time this version
+  is run. The settings file has changed to accommodate the new options,
+  so earlier settings files cannot be reused. Preferences have to be set
+  again in the settings menu and saved.
 
 
 # previous changes
@@ -97,7 +165,7 @@ For some configurations risc-v binaries are available. It is recommended however
 | Pico 2 | [PicoPeanutGB_AdafruitDVISD_pico2_arm.uf2](https://github.com/fhoedemakers/pico-peanutGB/releases/latest/download/PicoPeanutGB_AdafruitDVISD_pico2_arm.uf2) | [Readme](https://github.com/fhoedemakers/pico-infonesPlus/blob/main/README.md#pcb-with-raspberry-pi-pico-or-pico-2) |
 | Pico 2 W | [PicoPeanutGB_AdafruitDVISD_pico2_w_arm.uf2](https://github.com/fhoedemakers/pico-peanutGB/releases/latest/download/PicoPeanutGB_AdafruitDVISD_pico2_w_arm.uf2) | [Readme](https://github.com/fhoedemakers/pico-infonesPlus/blob/main/README.md#pcb-with-raspberry-pi-pico-or-pico-2) |
 
-PCB [pico_nesPCB_v2.3.zip](https://github.com/fhoedemakers/pico-peanutGB/releases/latest/download/pico_nesPCB_v2.3.zip)
+PCB [pico_nesPCB_v2.1.zip](https://github.com/fhoedemakers/pico-peanutGB/releases/latest/download/pico_nesPCB_v2.1.zip)
 
 3D-printed case designs for PCB:
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,58 @@
 # History of changes
 
+# v0.10 Release notes
+
+In this release PicoDVI is replaced with HSTX where possible, implements audio over HDMI using HSTX and adds a small convenience for flashing new firmware.
+
+A huge thank you to [@fliperama86](https://github.com/fliperama86) for the
+excellent [pico_hdmi](https://github.com/fliperama86/pico_hdmi) driver that
+made the new HDMI output possible, and for all the help along the way.
+
+## What's new
+
+### HSTX Video and sound over HDMI
+
+On the technical side, several RP2350 board configurations have switched
+from the **PicoDVI** software-driven video output to **HSTX**, the
+RP2350's dedicated High-Speed Serial Transmit hardware (GPIO 12 – 19).
+HSTX has been used for video on some boards before, but in this release
+it also carries **audio embedded in the HDMI stream** for the first
+time — that's the new capability HSTX gains here. (PicoDVI has always
+been able to embed audio; HSTX is just catching up on that front while
+offloading the work from the CPU to dedicated hardware.)
+
+In practice, on these boards picture and sound now travel together over a
+single HDMI cable — no separate audio jack needed:
+
+- Adafruit Fruit Jam
+- Murmulator M2
+
+To enable audio over HDMI, make sure external audio is disabled in the
+settings menu. If you'd rather keep using a separate audio output, you
+can switch the HSTX boards to **DVI mode** (video only, no embedded
+sound) from the settings menu. This setting automatically enables external audio in those configurations that support a DAC.
+
+These RP2350 boards have also been switched from PicoDVI to HSTX. (audio and Video):
+
+- [Breadboard build](https://github.com/fhoedemakers/pico-infonesPlus?tab=readme-ov-file#raspberry-pi-pico-or-pico-2-setup-with-adafruit-hardware-and-breadboard)
+- [PCB build](https://github.com/fhoedemakers/pico-infonesPlus?tab=readme-ov-file#pcb-with-raspberry-pi-pico-or-pico-2)
+- [Adafruit Metro RP2350](https://github.com/fhoedemakers/pico-infonesPlus?tab=readme-ov-file#adafruit-metro-rp2350)
+
+All other boards continue to use PicoDVI and work as before.
+
+### New options and conveniences
+
+- **Enter flashing mode from the settings menu**, so you can update the
+  firmware without having to unplug the device and hold the BOOTSEL button.
+
+### Reliability
+
+- **Resync watchdog for HSTX output.** On the new HSTX output when set
+  to video-only (DVI) mode, the monitor could occasionally lose the
+  picture. The emulator now detects this and automatically restores the
+  signal without needing a restart. (Not observed in full HDMI mode, but
+  the same safety net is enabled there too just in case.)
+
 # v0.9 Release Notes
 - Added support for [Murmulator M1 and M2 boards](https://murmulator.ru). [@javavi](https://github.com/javavi)  [#150](https://github.com/fhoedemakers/pico-infonesPlus/issues/150)
   - M1: RP2040/RP2350


### PR DESCRIPTION
This pull request introduces several new features, enhancements, and fixes, with a focus on adding support for `pico-bootLoader`, expanding controller compatibility, and improving display and stability. It also updates the build process to reflect new file locations and documents these changes in the changelogs. The previous v0.10 release notes have been moved to `HISTORY.md` to keep the main changelog focused on the latest release.

**Major new features and improvements:**

* **Support for `pico-bootLoader`:** The emulator can now be used with `pico-bootLoader`, allowing multiple emulators to be installed and selected at boot via a menu, with specific notes on usage and file locations.
* **Controller test screen and expanded controller support:** Adds a controller test screen in the settings menu and extends support for various controllers, including SNES, DualShock 4, DualSense, Xbox/XInput, Wii Classic, and more.
* **New display options:** Introduces an LCD-style scanline type, updates the scanline selection mechanism, and improves frame buffer alignment and HDMI output signal quality.

**Stability and reliability fixes:**

* **Stability improvements:** Fixes crashes related to loading large ROMs, stack overflows during settings operations, and SD card reliability, with special fixes for Adafruit Fruit Jam and Feather RP2350 boards.

**Build process and documentation updates:**

* **Build artifact path updates:** Updates the build workflow to reflect new locations for PCB files under `pico_shared/PCB/`.
* **Changelog and history maintenance:** Moves v0.10 release notes to `HISTORY.md` and documents all new features and fixes in `CHANGELOG.md`. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL3-R130) [[2]](diffhunk://#diff-648afe3d986261d8f2015b2b131b0e4a448d4dc6946cfde1a7a836876cee255eR3-R55)
* **Submodule update:** Updates the `pico_shared` submodule to the latest commit.